### PR TITLE
Remove WIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clipboard": "^1.7.1",
     "jquery": "^3.2.1",
     "list.js": "^1.5.0",
-    "phila-standards": "^0.11.2"
+    "phila-standards": "^0.13.2"
   },
   "devDependencies": {
     "browserify": "^14.1.0",

--- a/site-content/_index.md
+++ b/site-content/_index.md
@@ -6,8 +6,6 @@ menu:
     weight: 10
     pre: hide
 ---
-{{< panel wip >}}
-
 <div class="row">
 <div class="columns medium-16">
 <h2 class="contrast">Why standards are important</h2>

--- a/themes/phila.gov/layouts/partials/footer.html
+++ b/themes/phila.gov/layouts/partials/footer.html
@@ -57,19 +57,16 @@
                 <h3 class="h4 dark-gray">Interact with 311 online</h3>
                 <a href="http://iframe.publicstuff.com/#?client_id=242" class="button icon full-width clearfix">
                   <div class="valign">
-                    <i class="fa fa-bullhorn valign-cell"></i>
                     <div class="button-label valign-cell">Report a problem</div>
                   </div>
                 </a>
                 <a href="http://www.phila.gov/311/findananswer/Pages/default.aspx" class="button icon full-width clearfix">
                   <div class="valign">
-                    <i class="fa fa-question valign-cell"></i>
                     <div class="button-label valign-cell">Ask a question</div>
                   </div>
                 </a>
                 <a href="https://cityofphiladelphia.github.io/service-request-tracker/" class="button icon full-width clearfix">
                   <div class="valign">
-                    <i class="fa fa-check-square-o valign-cell"></i>
                     <div class="button-label valign-cell">Track a request</div>
                   </div>
                 </a>

--- a/themes/phila.gov/layouts/partials/global-header.html
+++ b/themes/phila.gov/layouts/partials/global-header.html
@@ -1,18 +1,5 @@
 <!-- Begin global header-->
 <h1 class="accessible">City of Philadelphia</h1>
-<!-- Beta opt-out -->
-<div data-swiftype-index="false" class="alert alert-persistent">
-  <div class="row">
-    <div class="small-24 columns">
-      <p class="hide-for-small-only">
-        We're piloting a new, user-friendly website design. To view the existing City website, visit <a class="go-back external" aria-label="back to phila.gov" href="http://www.phila.gov?opt-out">phila.gov</a>.
-      </p>
-      <p class="show-for-small-only">
-        Back to <a class="go-back external" aria-label="back to phila.gov" href="http://www.phila.gov?opt-out">phila.gov</a>.
-      </p>
-    </div>
-  </div>
-</div>
 <!-- Utility Navigation -->
 <div class="row columns bg-ben-franklin-blue expanded utility-nav" data-swiftype-index="false">
   <div class="row">

--- a/themes/phila.gov/layouts/partials/head.html
+++ b/themes/phila.gov/layouts/partials/head.html
@@ -14,7 +14,7 @@
     <link href="{{ .Site.BaseURL }}/css/phila-app.min.css" rel="stylesheet">
     {{end}}
 
-    <link rel="shortcut icon" type="image/x-icon" href="http://standards.phila.gov/img/favicon.png">
+    <link rel="shortcut icon" type="image/x-icon" href="https://standards.phila.gov/img/favicon.png">
 
     {{ $directory := "static/css" }}
     {{ $filename := "styles.css" }}


### PR DESCRIPTION
* Use https favicon.
* Update to standards 0.13.2.
* Remove work in progress and back to phila.gov link.